### PR TITLE
Change exit handling to skip exit handlers

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -52,7 +52,9 @@ def do_work (command)
     exit_status = wait_thr.value
     unless exit_status.success?
       do_unlock($lf)
-      abort "The command #{command} failed!"
+      puts "The command #{command} failed!"
+      # Do not run through the standard exit handlers
+      exit!(1)
     end
   end  
 end  

--- a/hwtest.rb
+++ b/hwtest.rb
@@ -134,7 +134,9 @@ def do_work (command)
     end
     exit_status = wait_thr.value
     unless exit_status.success?
-      abort "The command #{command} failed!"
+      puts "The command #{command} failed!"
+      # Do not run through the standard exit handlers
+      exit!(1)
     end
   end  
 end  


### PR DESCRIPTION
@hanssaurer This is an attempt to avoid zombie processes by telling Sinatra to NOT run its exit handlers.
