### PR TITLE
Adding unit tests for cameras and buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tstsub.rb
 .lockfile
 .subl*
 .hans.yml
+animated.gif

--- a/bucket.rb
+++ b/bucket.rb
@@ -37,5 +37,6 @@ def results_upload(bucket_name, local_file, results_file)
   #key = File.basename(results_file)
   s3.buckets[bucket_name].objects[results_file].write(:file => local_file)
   puts "Uploading file #{local_file} to #{results_file} in bucket #{bucket_name}."
+  puts "Link: http://#{bucket_name}/#{results_file}"
   return true
 end

--- a/bucket.rb
+++ b/bucket.rb
@@ -1,17 +1,41 @@
-#!/usr/bin/env ruby
 
 require 'rubygems'
 require 'aws-sdk'
 
-bucket_name = 'results.dronetest.io'
-file_name = 'test.txt'
+def results_claim_directory(bucket_name, host)
+  # Get an instance of the S3 interface.
+  s3 = AWS::S3.new
+  bucket = s3.buckets[bucket_name]
 
-File.open(file_name, 'w') {|f| f.write(Time.now.strftime("%d/%m/%Y %H:%M")) }
+  if !bucket.exists?
+    puts 'Bucket ' + bucket_name + ' does not exit!'
+    return nil
+  end
 
-# Get an instance of the S3 interface.
-s3 = AWS::S3.new
+  filename = ''
 
-# Upload a file.
-key = File.basename(file_name)
-s3.buckets[bucket_name].objects[key].write(:file => file_name)
-puts "Uploading file #{file_name} to bucket #{bucket_name}."
+  bucket.objects.each do |obj|
+    filename = obj.key
+    puts filename
+  end
+
+  return filename
+end
+
+def results_upload(bucket_name, local_file, results_file)
+
+  # Get an instance of the S3 interface.
+  s3 = AWS::S3.new
+  bucket = s3.buckets[bucket_name]
+
+  if !bucket.exists?
+    puts 'Bucket ' + bucket_name + ' does not exit!'
+    return false
+  end
+
+  # Upload a file.
+  #key = File.basename(results_file)
+  s3.buckets[bucket_name].objects[results_file].write(:file => local_file)
+  puts "Uploading file #{local_file} to #{results_file} in bucket #{bucket_name}."
+  return true
+end

--- a/cam.rb
+++ b/cam.rb
@@ -1,19 +1,24 @@
 #!/usr/bin/env ruby
 
+require 'fileutils'
 require 'rb_webcam'
 require 'RMagick'
 include Magick
 
-capture = Webcam.new(0)
+def take_picture(workingdir)
+  capture = Webcam.new(0)
 
-# Capture 30 frames
-for i in 0..30
-  image = capture.grab
-  image.save "new_image%d.jpg" % i
+  # Capture 30 frames
+  for i in 0..30
+    image = capture.grab
+    image.save "%s/new_image%d.jpg" % [workingdir, i]
+  end
+  capture.close
+
+  # Create a GIF using these frames
+  animation = ImageList.new(*Dir["*.jpg"])
+  animation.delay = 10
+  animation.write("%s/animated.gif" % workingdir)
+  FileUtils.rm_rf(Dir.glob("%s/*.jpg" % workingdir))
+  return true
 end
-capture.close
-
-# Create a GIF using these frames
-animation = ImageList.new(*Dir["*.jpg"])
-animation.delay = 10
-animation.write("animated.gif")

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Initialize environment
+. config.txt
+
+# Run tests
+ruby unittests/tc_bucket.rb
+ruby unittests/tc_cam.rb

--- a/unittests/tc_bucket.rb
+++ b/unittests/tc_bucket.rb
@@ -19,7 +19,7 @@ class TestBucket < Test::Unit::TestCase
     # Write test file
     File.open(file_name, 'w') {|f| f.write(Time.now.strftime("%d/%m/%Y %H:%M")) }
 
-    upload_result = results_upload(bucket_name, file_name, claimed_dir)
+    upload_result = results_upload(bucket_name, file_name, "%s/%s" % [claimed_dir, file_name])
 
     # Cleanup
     FileUtils.rm_rf(file_name);

--- a/unittests/tc_bucket.rb
+++ b/unittests/tc_bucket.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+require_relative "../bucket"
+require "test/unit"
+require 'fileutils'
+
+class TestBucket < Test::Unit::TestCase
+ 
+  def test_bucket
+
+    puts("\n")
+
+    bucket_name = 'results.dronetest.io'
+    host = 'test01'
+    file_name = 'localtest.txt'
+    test_count = '005'
+
+    claimed_dir = "%s/%s" % [host, test_count]
+
+    # Write test file
+    File.open(file_name, 'w') {|f| f.write(Time.now.strftime("%d/%m/%Y %H:%M")) }
+
+    upload_result = results_upload(bucket_name, file_name, claimed_dir)
+
+    # Cleanup
+    FileUtils.rm_rf(file_name);
+
+  # Claim dir
+  #puts "Claiming directory"
+  #dir = results_claim_directory(bucket_name, host)
+
+  #puts = "New dir: " + dir + "\n"
+
+    assert_equal(true, upload_result, "Upload test failed")
+  end
+ 
+end

--- a/unittests/tc_cam.rb
+++ b/unittests/tc_cam.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+require_relative "../cam"
+require "test/unit"
+
+class TestBucket < Test::Unit::TestCase
+ 
+  def test_cam
+
+    puts("\n")
+
+    cam_result = take_picture(".")
+    puts "Leaving animated.gif for inspection"
+    assert_equal(true, cam_result, "Camera picture test failed")
+  end
+ 
+end


### PR DESCRIPTION
This adds unit tests for these two modules, which greatly simplifies testing and allows the use of the modules in build.rb without any command line usage.
